### PR TITLE
Исправил ошибку в команде docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
    bash app/data/example4.bash
 6. Результат выполнения скрипта на скриншоте "Снимок экрана от 2024-02-08 21-59-05_1"
 Коментарий. К сожалению не получилось автоматизировать запуск баш скрипта, образ контейнера не хочет пересобираться :
-   docker build -t humble-desktop-prepaired                  
+   docker build . -t humble-desktop-prepaired                  
    ERROR: "docker buildx build" requires exactly 1 argument.
    See 'docker buildx build --help'.
 


### PR DESCRIPTION
Команда сборки docker образа скорее всего не выполнялась из-за пропущенного аргумента, указывающего путь к dockerfile. 

Если поставить точку (.) вместо пути, то команда будет искать dockerfile в текущей директории.

Попробуйте снова сделать сборку. Если все ок, принимайте мои изменения из pull request.

**Обязательно потом отпишитесь на платформе skillbox, иначе не смогу принять работу!**